### PR TITLE
Add LimitPixels and FillArea to MagickGeometry

### DIFF
--- a/GraphicsMagick.NET.Tests/Arguments/MagickGeometryTests.cs
+++ b/GraphicsMagick.NET.Tests/Arguments/MagickGeometryTests.cs
@@ -59,7 +59,17 @@ namespace GraphicsMagick.NET.Tests
 			Assert.AreEqual(true, geometry.IsPercentage);
 			Assert.AreEqual(true, geometry.Greater);
 
-			geometry = new MagickGeometry(5, 10);
+		    geometry = new MagickGeometry("5x10@");
+		    Assert.AreEqual(5, geometry.Width);
+		    Assert.AreEqual(10, geometry.Height);
+		    Assert.AreEqual(true, geometry.LimitPixels);
+
+		    geometry = new MagickGeometry("5x10^");
+		    Assert.AreEqual(5, geometry.Width);
+		    Assert.AreEqual(10, geometry.Height);
+		    Assert.AreEqual(true, geometry.FillArea);
+
+            geometry = new MagickGeometry(5, 10);
 			Assert.AreEqual(5, geometry.Width);
 			Assert.AreEqual(10, geometry.Height);
 

--- a/GraphicsMagick.NET/Arguments/MagickGeometry.cpp
+++ b/GraphicsMagick.NET/Arguments/MagickGeometry.cpp
@@ -1,7 +1,7 @@
 //=================================================================================================
 // Copyright 2014-2015 Dirk Lemstra <https://graphicsmagick.codeplex.com/>
 //
-// Licensed under the ImageMagick License (the "License"); you may not use this file except in 
+// Licensed under the ImageMagick License (the "License"); you may not use this file except in
 // compliance with the License. You may obtain a copy of the License at
 //
 //   http://www.imagemagick.org/script/license.php
@@ -27,6 +27,8 @@ namespace GraphicsMagick
 		IgnoreAspectRatio = geometry.aspect();
 		Less = geometry.less();
 		Greater = geometry.greater();
+		LimitPixels = geometry.limitPixels();
+		FillArea = geometry.fillArea();
 	}
 	//==============================================================================================
 	void MagickGeometry::Initialize(int x, int y, int width, int height, bool isPercentage)
@@ -50,6 +52,8 @@ namespace GraphicsMagick
 		result->aspect(IgnoreAspectRatio);
 		result->less(Less);
 		result->greater(Greater);
+		result->limitPixels(LimitPixels);
+		result->fillArea(FillArea);
 
 		return result;
 	}
@@ -187,13 +191,15 @@ namespace GraphicsMagick
 
 		return
 			Width == other->Width &&
-			Height == other->Height && 
+			Height == other->Height &&
 			X == other->X &&
 			Y == other->Y &&
 			IsPercentage == other->IsPercentage &&
 			IgnoreAspectRatio == other->IgnoreAspectRatio &&
 			Less == other->Less &&
-			Greater == other->Greater;
+			Greater == other->Greater &&
+			LimitPixels == other->LimitPixels &&
+			FillArea == other->FillArea;
 	}
 	//==============================================================================================
 	int MagickGeometry::GetHashCode()
@@ -206,7 +212,9 @@ namespace GraphicsMagick
 			IsPercentage.GetHashCode() ^
 			IgnoreAspectRatio.GetHashCode() ^
 			Less.GetHashCode() ^
-			Greater.GetHashCode();
+			Greater.GetHashCode() ^
+			LimitPixels.GetHashCode() ^
+			FillArea.GetHashCode();
 	}
 	//==============================================================================================
 	String^ MagickGeometry::ToString()
@@ -221,6 +229,6 @@ namespace GraphicsMagick
 		{
 			delete geometry;
 		}
-	} 
+	}
 	//==============================================================================================
 }

--- a/GraphicsMagick.NET/Arguments/MagickGeometry.h
+++ b/GraphicsMagick.NET/Arguments/MagickGeometry.h
@@ -1,7 +1,7 @@
 //=================================================================================================
 // Copyright 2014-2015 Dirk Lemstra <https://graphicsmagick.codeplex.com/>
 //
-// Licensed under the ImageMagick License (the "License"); you may not use this file except in 
+// Licensed under the ImageMagick License (the "License"); you may not use this file except in
 // compliance with the License. You may obtain a copy of the License at
 //
 //   http://www.imagemagick.org/script/license.php
@@ -138,6 +138,16 @@ namespace GraphicsMagick
 		/// Y offset from origin
 		///</summary>
 		property int Y;
+		///==========================================================================================
+		///<summary>
+		/// Resize image to fit total pixel area specified by dimensions (@)
+		///</summary>
+		property bool LimitPixels;
+		///==========================================================================================
+		///<summary>
+		/// Resize image to fit a set of dimensions (^)
+		///</summary>
+		property bool FillArea;
 		//===========================================================================================
 		static bool operator == (MagickGeometry^ left, MagickGeometry^ right);
 		//===========================================================================================
@@ -181,7 +191,7 @@ namespace GraphicsMagick
 		///<summary>
 		/// Returns a string that represents the current geometry.
 		///</summary>
-		virtual String^ ToString() override; 
+		virtual String^ ToString() override;
 		//===========================================================================================
 	};
 	//==============================================================================================


### PR DESCRIPTION
Added support for the new(ish) LimitPixels and FillArea properties on MagickGeometry, used by the Resize and Thumbnail functions.

I was unable to get things to build because I do not have VS 2012 installed, the pre-built libs you have on dropbox seem to be built in that version so I can't link against them, even if I update the platform version so that I can compile the source.

I saw that you have AppVeyor scripts, so hopefully this PR will kick off a build and we can be sure it works.